### PR TITLE
Fixes Join's doesn't have a parameter to define AS

### DIFF
--- a/lib/src/mysql_model.dart
+++ b/lib/src/mysql_model.dart
@@ -63,11 +63,11 @@ class MTable implements SQL {
   /// final fields = table.getFieldsAs('u', 'user');
   /// // Generates: u.id AS user.id, u.name AS user.name, etc.
   /// ```
-  List<QSelectField> getFieldsAs(String from, String as) {
+  List<QSelectField> getFieldsAs([String from = '', String newAlias = '']) {
     return fields.map((field) {
-      return QSelectCustom(
-        QMath(from.isEmpty ? field.name : "$from.${field.name}"),
-        as: as.isEmpty ? field.name : '$as.${field.name}',
+      return QSelect(
+        from.isEmpty ? field.name : '$from.${field.name}',
+        as: newAlias.isEmpty ? '' : '${newAlias}_${field.name}',
       );
     }).toList();
   }

--- a/lib/src/mysql_query.dart
+++ b/lib/src/mysql_query.dart
@@ -987,6 +987,27 @@ class QSelectCustom implements QSelectField {
   }
 }
 
+class QSelectString implements QSelectField {
+  /// The string value to select
+  String value;
+
+  /// Creates a SELECT field for a string value.
+  ///
+  /// [value] The string value to select.
+  QSelectString(this.value);
+
+  /// Returns the string value wrapped in quotes.
+  ///
+  /// Example:
+  /// ```dart
+  /// QSelectString('Hello, World!').toSQL(); // "'Hello, World!'"
+  /// ```
+  @override
+  String toSQL() {
+    return value;
+  }
+}
+
 /// Represents a mathematical expression or function in a SELECT clause.
 ///
 /// This class allows embedding raw SQL mathematical expressions, aggregate functions,
@@ -1970,39 +1991,43 @@ class Limit implements SQL {
 
 class Join implements SQL {
   String table;
+  String as;
   On on;
-  Join(this.table, this.on);
+  Join(this.table, this.on, {this.as = ''});
 
   @override
   String toSQL() {
+    var sqlAs = as.isNotEmpty ? ' AS ${QField(as).toSQL()}' : '';
     if (on._onBodies.isNotEmpty) {
-      return 'JOIN ${QField(table).toSQL()} ON ${on.toSQL()}';
+      return 'JOIN ${QField(table).toSQL()}$sqlAs ON ${on.toSQL()}';
     }
-    return 'JOIN ${QField(table).toSQL()}';
+    return 'JOIN ${QField(table).toSQL()}$sqlAs';
   }
 }
 
 class LeftJoin extends Join {
-  LeftJoin(super.table, super.on);
+  LeftJoin(super.table, super.on, {super.as = ''});
 
   @override
   String toSQL() {
+    var sqlAs = as.isNotEmpty ? ' AS ${QField(as).toSQL()}' : '';
     if (on._onBodies.isNotEmpty) {
-      return 'LEFT JOIN ${QField(table).toSQL()} ON ${on.toSQL()}';
+      return 'LEFT JOIN ${QField(table).toSQL()}$sqlAs ON ${on.toSQL()}';
     }
-    return 'LEFT JOIN ${QField(table).toSQL()}';
+    return 'LEFT JOIN ${QField(table).toSQL()}$sqlAs';
   }
 }
 
 class RightJoin extends Join {
-  RightJoin(super.table, super.on);
+  RightJoin(super.table, super.on, {super.as = ''});
 
   @override
   String toSQL() {
+    var sqlAs = as.isNotEmpty ? ' AS ${QField(as).toSQL()}' : '';
     if (on._onBodies.isNotEmpty) {
-      return 'RIGHT JOIN ${QField(table).toSQL()} ON ${on.toSQL()}';
+      return 'RIGHT JOIN ${QField(table).toSQL()}$sqlAs ON ${on.toSQL()}';
     }
-    return 'RIGHT JOIN ${QField(table).toSQL()}';
+    return 'RIGHT JOIN ${QField(table).toSQL()}$sqlAs';
   }
 }
 


### PR DESCRIPTION
Fixes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - JOIN sources can now be aliased in generated SQL (e.g., JOIN table AS alias).
  - Added support to include raw SQL strings in SELECT lists.
  - Field selection helper now accepts optional parameters, making it easier to compose queries.
  - Updated field aliasing: uses underscore separators and omits aliases when not provided.
- Tests
  - Added a LEFT JOIN integration test using books and categories to validate aliasing and combined field selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->