### PR TITLE
Fixed #23 parse the name of table while joining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+- Fixed table name for JOIN's #23, #21
+
 ## 1.1.2
 
 - Password QVar `QVar.password('test', hashType: HashType.sha1)` support sha1, md5(default), sha256, sha512, HMAC-SHA256
@@ -5,7 +9,7 @@
 
 ## 1.1.0
 
-- Added DISTINCT for QField
+- Added DISTINCT for QField #16
 - Improve the Aggregate Functions #1
 - Added Validator functionalty for input variables in MField and MTable
 

--- a/lib/src/mysql_query.dart
+++ b/lib/src/mysql_query.dart
@@ -2004,7 +2004,12 @@ class Join implements SQL {
   String table;
   String as;
   On on;
-  Join(this.table, this.on, {this.as = ''});
+  Join(this.table, this.on, {this.as = ''}) {
+    if (as.isEmpty && table.contains(' ')) {
+      as = table.split(' ').last.trim();
+      table = table.split(' ').first.trim();
+    }
+  }
 
   @override
   String toSQL() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for inline table alias syntax in JOIN clauses (e.g., "users u") to be parsed automatically into table and alias.
- Bug Fixes
  - Corrected table name handling in JOINs, ensuring accurate SQL generation (addresses #23, #21).
- Documentation
  - Updated changelog with 1.1.3 entry and clarified references in 1.1.0.
- Tests
  - Added equivalence tests verifying that independently constructed queries produce identical SQL and results, including first/last row comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->